### PR TITLE
Use forked Segment Adjust integration

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -31,7 +31,7 @@
         <source-file src="src/android/SegmentCordovaPlugin.java" target-dir="src/com/segment/cordova/plugin" />
 
         <framework src="com.segment.analytics.android:analytics:4.3.0"/>
-        <framework src="com.segment.analytics.android.integrations:adjust:+" />
+        <framework src="src/android/build.gradle" custom="true" type="gradleReference"/>
     </platform>
 
     <platform name="ios">

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -3,5 +3,5 @@ repositories {
 }
 
 dependencies {
-	compile 'com.github.Jojnts:analytics-android-integration-adjust:7f588be'
+	compile 'com.github.Jojnts:analytics-android-integration-adjust:master'
 }

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -1,0 +1,7 @@
+repositories {
+	maven { url "https://jitpack.io" }
+}
+
+dependencies {
+	compile 'com.github.Jojnts:analytics-android-integration-adjust:7f588be'
+}


### PR DESCRIPTION
Forked the Segment Adjust integration to fix the initial process that is supposed to be kicked off by a call to onResume() that unfortunately does not happen in Cordova. Forked repo: https://github.com/Jojnts/analytics-android-integration-adjust/commit/7f588be774dad512340bab860291bac0d9b46b4f